### PR TITLE
Upgrade `image` to `0.24.5`, prepare for 0.2.0

### DIFF
--- a/.github/workflows/rust-cd.yml
+++ b/.github/workflows/rust-cd.yml
@@ -62,32 +62,16 @@ jobs:
           toolchain: ${{ matrix.rust }}
           args: --release --example skeletonize --target ${{ matrix.platform.target }}
 
-      - name: Install strip command
-        if: ${{ matrix.platform.target == 'aarch64-unknown-linux-gnu' }}
-        shell: bash
-        run: |
-          sudo apt update
-          sudo apt-get install -y binutils-aarch64-linux-gnu
-
       - name: Package final binary
         shell: bash
         run: |
           cd target/${{ matrix.platform.target }}/release/examples
-          ####### reduce binary size by removing debug symbols #######
           BINARY_NAME=skeletonize${{ matrix.platform.binary-postfix }}
-          if [[ ${{ matrix.platform.target }} == aarch64-unknown-linux-gnu ]]; then
-            GCC_PREFIX="aarch64-linux-gnu-"
-          else
-            GCC_PREFIX=""
-          fi
-
-          if [[ ${{ matrix.platform.target }} != x86_64-pc-windows-msvc ]]; then
-            "$GCC_PREFIX"strip $BINARY_NAME
-          fi
 
           ########## create tar.gz ##########
           RELEASE_NAME=skeletonize-${GITHUB_REF/refs\/tags\//}-${{ matrix.platform.os-name }}-${{ matrix.platform.architecture }}
           tar czvf $RELEASE_NAME.tar.gz $BINARY_NAME
+
           ########## create sha256 ##########
           if [[ ${{ runner.os }} == 'Windows' ]]; then
             certutil -hashfile $RELEASE_NAME.tar.gz sha256 | grep -E [A-Fa-f0-9]{64} > $RELEASE_NAME.sha256

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 # `skeletonize` changelog
 
+## Version 0.2.0 - 2023-01-14
+Bumped `image` dependency to `0.24`.
+
+[#2][2] - Upgrade `image` to `0.24.5`, prepare new release
+
 ## Version 0.1.0 - 2021-05-01
 - Initial release
+
+[2]: https://github.com/okaneco/skeletonize/pull/2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skeletonize"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["okaneco <47607823+okaneco@users.noreply.github.com>"]
 edition = "2018"
 exclude = ["gfx", ".github"]
@@ -16,11 +16,11 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 
 [dependencies.image]
-version = "0.23"
+version = "0.24.5"
 default-features = false
 
 [dev-dependencies.image]
-version = "0.23"
+version = "0.24.5"
 default-features = false
 features = ["jpeg", "png", "gif"]
 
@@ -30,3 +30,6 @@ default-features = false
 
 [[example]]
 name = "skeletonize"
+
+[profile.release]
+strip = true

--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -175,7 +175,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright 2021 Collyn O'Kane
+   Copyright 2021-2023 Collyn O'Kane
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright 2021 Collyn O'Kane
+Copyright 2021-2023 Collyn O'Kane
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # skeletonize
 
-[![Build Status](https://img.shields.io/github/workflow/status/okaneco/skeletonize/Rust%20CI/master)](https://github.com/okaneco/skeletonize/actions)
+[![Build Status](https://github.com/okaneco/skeletonize/workflows/Rust%20CI/badge.svg)](https://github.com/okaneco/skeletonize/)
 [![Crates.io](https://img.shields.io/crates/v/skeletonize.svg)](https://crates.io/crates/skeletonize)
 [![Docs.rs](https://docs.rs/skeletonize/badge.svg)](https://docs.rs/skeletonize)
 
@@ -23,7 +23,7 @@ crate, add the following to your `Cargo.toml`.
 
 ```toml
 [dependencies.skeletonize]
-version = "0.1"
+version = "0.2"
 ```
 
 #### Features

--- a/examples/skeletonize.rs
+++ b/examples/skeletonize.rs
@@ -4,7 +4,7 @@ use structopt::StructOpt;
 
 fn main() {
     if let Err(e) = try_main() {
-        eprintln!("{}", e);
+        eprintln!("{e}");
         std::process::exit(1);
     }
 }
@@ -13,7 +13,7 @@ fn try_main() -> Result<(), Box<dyn std::error::Error>> {
     let mut opt = Opt::from_args();
 
     // Open image and initialize output filename
-    let img = image::open(&opt.input)?.grayscale();
+    let img = image::DynamicImage::ImageLuma8(image::open(&opt.input)?.to_luma8());
     let output = if let Some(output) = opt.output {
         output
     } else {

--- a/src/edge_detection.rs
+++ b/src/edge_detection.rs
@@ -34,6 +34,7 @@ pub const SOBEL_WEST: [f32; 9] = [
 
 /// Detect edges in an image using [`SOBEL_EAST`](SOBEL_EAST) and
 /// [`SOBEL_NORTH`](SOBEL_NORTH) gradient operators.
+/// The image should not have transparency.
 ///
 /// `threshold` is an optional parameter between 0.0 and 1.0 which is used to
 /// binarize the image. Pixels below that `Luma` threshold will be converted
@@ -44,7 +45,6 @@ pub fn sobel<F: ForegroundColor>(
 ) -> Result<image::DynamicImage, SkeletonizeError> {
     let mut filter_up = img.filter3x3(&SOBEL_NORTH);
     let filtered_right = img.filter3x3(&SOBEL_EAST);
-
     let mutable_error = SkeletonizeError::LumaConversion(LumaConversionErrorKind::SobelMutableLuma);
     let immutable_error = SkeletonizeError::LumaConversion(LumaConversionErrorKind::SobelLuma);
 
@@ -77,6 +77,7 @@ pub fn sobel<F: ForegroundColor>(
 /// Detect edges in an image using four Sobel gradient operators:
 /// [`SOBEL_NORTH`](SOBEL_NORTH), [`SOBEL_SOUTH`](SOBEL_SOUTH),
 /// [`SOBEL_EAST`](SOBEL_EAST), and [`SOBEL_WEST`](SOBEL_WEST).
+/// The image should not have transparency.
 ///
 /// `threshold` is an optional parameter between 0.0 and 1.0 which is used to
 /// binarize the image. Pixels below that `Luma` threshold will be converted

--- a/src/error.rs
+++ b/src/error.rs
@@ -46,7 +46,7 @@ impl core::fmt::Display for LumaConversionErrorKind {
 impl core::fmt::Display for SkeletonizeError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            Self::LumaConversion(err) => write!(f, "{}", err),
+            Self::LumaConversion(err) => write!(f, "{err}"),
             Self::MaxThinningIterations => {
                 write!(f, "Maximum iteration count reached in thinning algorithm")
             }

--- a/src/thinning.rs
+++ b/src/thinning.rs
@@ -11,6 +11,8 @@ use crate::{Edge, ForegroundColor, MarkingMethod};
 /// needed for thinning on successful completion.
 ///
 /// `iterations` is an optional parameter set to `u32::MAX` if `None`.
+#[allow(clippy::collapsible_else_if)]
+#[allow(clippy::nonminimal_bool)]
 pub fn thin_image_edges<F: ForegroundColor>(
     img: &mut image::DynamicImage,
     method: MarkingMethod,
@@ -32,7 +34,7 @@ pub fn thin_image_edges<F: ForegroundColor>(
                 continue;
             }
 
-            let info = get_neighbor_info::<F>(&luma_img, width, height, x, y);
+            let info = get_neighbor_info::<F>(luma_img, width, height, x, y);
             let [p2, p3, p4, p5, p6, p7, p8, p9] = info.edge_status;
 
             match method {


### PR DESCRIPTION
Bump `image` version
Convert image in example to_luma8 because alpha is preserved otherwise
Add strip to profile-release, update CD action
Change readme.md badge to use github version
Ignore clippy lints in `thinning::thin_image_edges` Update changelog